### PR TITLE
Add support for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     }
   },
   "require": {
-    "php": "^7.1.3",
+    "php": ">=7.1.3",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "monolog/monolog": "^1.12|^2.0",
     "psr/log": "^1.1"


### PR DESCRIPTION
Close #7 

I was able to execute this
` /usr/local/Cellar/php/8.0.1_1/bin/php composer.phar install `

and

```/usr/local/Cellar/php/8.0.1_1/bin/php ./vendor/bin/phpunit
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.1
Configuration: /usr/local/Cellar/php/8.0.1_1/bin/laravel-logzio/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

..............                                                    14 / 14 (100%)

Time: 00:00.117, Memory: 18.00 MB

OK (14 tests, 28 assertions)
```
