### PR TITLE
Allow configurable timestamp format

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -61,14 +61,15 @@ In `config/logging.php` file, config you log with driver `logzio`
 return [
     // ...
 	'custom' => [
-	    'driver' => 'logzio',
-	    'name'   => 'channel-name',
-	    'token'  => 'logz-access-token',
-	    'type'   => 'http-bulk',
-	    'ssl'    => true,
-	    'level'  => 'info',
-	    'bubble' => true,
-	    'region' => 'eu', // leave empty for default region
+	    'driver'           => 'logzio',
+	    'name'             => 'channel-name',
+	    'token'            => 'logz-access-token',
+	    'type'             => 'http-bulk',
+	    'ssl'              => true,
+	    'level'            => 'info',
+	    'bubble'           => true,
+	    'region'           => 'eu', // leave empty for default region
+	    'timestamp_format' => '', // leave empty for default format (requires UTC time)
 	],
 	// ...
 ];

--- a/src/Log/Formatter.php
+++ b/src/Log/Formatter.php
@@ -15,19 +15,16 @@ use Monolog\Formatter\JsonFormatter;
  */
 class Formatter extends JsonFormatter implements FormatterInterface
 {
-    /**
-     * Datetime format for Logz.io
-     * @see https://support.logz.io/hc/en-us/articles/210206885
-     */
-    protected const DATETIME_FORMAT = 'c';
+    private $timestampFormat;
 
     /**
      * @param  int  $batchMode
      * @param  bool $appendNewline
      */
-    public function __construct(int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = true)
+    public function __construct(string $timestampFormat, int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = true)
     {
         parent::__construct($batchMode, $appendNewline);
+        $this->timestampFormat = $timestampFormat;
     }
 
     /**
@@ -39,7 +36,7 @@ class Formatter extends JsonFormatter implements FormatterInterface
     public function format(array $record): string
     {
         if (isset($record["datetime"]) && ($record["datetime"] instanceof DateTimeInterface)) {
-            $record["@timestamp"] = $record["datetime"]->format(self::DATETIME_FORMAT);
+            $record["@timestamp"] = $record["datetime"]->format($this->timestampFormat);
 
             unset($record["datetime"]);
         }

--- a/src/Log/Handler.php
+++ b/src/Log/Handler.php
@@ -22,6 +22,10 @@ use Monolog\Logger;
  */
 final class Handler extends AbstractProcessingHandler
 {
+    // Default timestamp format matches Logz.io expected format:
+    // https://support.logz.io/hc/en-us/articles/210206885
+    const TIMESTAMP_FORMAT = 'Y-m-d\TH:i:s.v\Z';
+
     /**
      * The HTTP client
      *
@@ -120,7 +124,7 @@ final class Handler extends AbstractProcessingHandler
      */
     protected function getDefaultFormatter(): FormatterInterface
     {
-        return new Formatter();
+        return new Formatter($options['timestamp_format'] ?? self::TIMESTAMP_FORMAT);
     }
 
     /**

--- a/src/Log/Handler.php
+++ b/src/Log/Handler.php
@@ -39,6 +39,11 @@ final class Handler extends AbstractProcessingHandler
     private $endpoint;
 
     /**
+     * @var string
+     */
+    private $timestampFormat;
+
+    /**
      * @param  int|string $level   The minimum logging level to trigger this handler.
      * @param  bool       $bubble  Whether or not messages that are handled should bubble up the stack.
      * @param  array      $options Logz.io client options
@@ -52,6 +57,7 @@ final class Handler extends AbstractProcessingHandler
 
         $this->client = $this->buildHttpClient($options);
         $this->endpoint = $this->buildEndpoint($options);
+        $this->timestampFormat = $options['timestamp_format'] ?? self::TIMESTAMP_FORMAT;
 
         parent::__construct($level, $bubble);
     }
@@ -124,7 +130,7 @@ final class Handler extends AbstractProcessingHandler
      */
     protected function getDefaultFormatter(): FormatterInterface
     {
-        return new Formatter($options['timestamp_format'] ?? self::TIMESTAMP_FORMAT);
+        return new Formatter($this->timestampFormat);;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,6 +38,7 @@ class ServiceProvider extends IlluminateServiceProvider
             //     'type' => 'http-bulk',
             //     'ssl' => true,
             //     'region' => '',
+            //     'timestamp_format' => '',
             // ];
             $handler = new Handler(
                 $config['level'] ?? 'warning',


### PR DESCRIPTION
Hey there! Handy package you've got here.

I'm using this in a context where I really needed millisecond precision for my timestamps and I noticed that the datetime format was hardcoded in the the `Formatter`. I've expanded this so that the timestamp format gets injected into the `Formatter` when it gets instantiated and the format comes from the logger config so the user can define it as they see fit.

The new default matches the [link you pointed to in a comment](https://support.logz.io/hc/en-us/articles/210206885) but because the `\Z` is hardcoded onto the end to conform to their standard, this really only works for servers that are using UTC time as their standard.

Under PHP 8, you could set `TIMESTAMP_FORMAT = 'Y-m-d\TH:i:s.vp'` and the `p` on the end will resolve to either `Z` for UTC or `+00:00` format for anything else. I didn't do this because I'm running PHP 7.4 and because there are still a lot of people who aren't on PHP 8 and I figured it best to maintain backward compatibility. Now that it's configurable, the end-user can always change it for their use case.